### PR TITLE
Update zoomBotAdvanced.py

### DIFF
--- a/zoomBotAdvanced.py
+++ b/zoomBotAdvanced.py
@@ -91,7 +91,7 @@ def openClass(classLists):
     found = False
     
         for word in classLists:
-        if "://" in word:
+        if "instructure" in word:
             word = word.replace("\n", "")
             canvasLogin(word)
 


### PR DESCRIPTION
Fixed bug from last update
Line 94 changed "://" to "instructure"
Zoom links also contain the :// so the bot would break.
Zoom links dont contain instructure